### PR TITLE
Add a connection that only weakly references its listener

### DIFF
--- a/src/main/java/react/AbstractSignal.java
+++ b/src/main/java/react/AbstractSignal.java
@@ -26,6 +26,12 @@ public class AbstractSignal<T> extends Reactor<Slot<T>>
         };
     }
 
+    public AbstractSignal() {
+        super(new Slot<T>() {
+            @Override public void onEmit(T event) {}
+        });
+    }
+
     @Override public Connection connect (Slot<? super T> slot) {
         // alas, Java does not support higher kinded types; this cast is safe
         @SuppressWarnings("unchecked") Slot<T> casted = (Slot<T>)slot;
@@ -47,7 +53,7 @@ public class AbstractSignal<T> extends Reactor<Slot<T>>
         try {
             for (Cons<Slot<T>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onEmit(event);
+                    cons.getListener().onEmit(event);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);

--- a/src/main/java/react/Cons.java
+++ b/src/main/java/react/Cons.java
@@ -10,13 +10,10 @@ import react.Reactor.RListener;
 /**
  * Implements {@link Connection} and a linked-list style listener list for {@link Reactor}s.
  */
-class Cons<L extends RListener> implements Connection
+abstract class Cons<L extends RListener> implements Connection
 {
     /** The reactor that owns this cons cell. */
     public final Reactor<L> owner;
-
-    /** Receives signals from the reactor. */
-    public final L listener;
 
     /** The next connection in our chain. */
     public Cons<L> next;
@@ -24,10 +21,11 @@ class Cons<L extends RListener> implements Connection
     /** Indicates whether this connection is one-shot or persistent. */
     public boolean oneShot;
 
-    public Cons (Reactor<L> owner, L listener) {
+    public Cons(Reactor<L> owner) {
         this.owner = owner;
-        this.listener = listener;
     }
+
+    abstract public L getListener();
 
     @Override public Connection once () {
         oneShot = true;
@@ -39,14 +37,14 @@ class Cons<L extends RListener> implements Connection
     }
 
     @Override public String toString () {
-        return "[owner=" + owner + ", lner=" + listener + ", hasNext=" + (next != null) +
+        return "[owner=" + owner + ", lner=" + getListener() + ", hasNext=" + (next != null) +
             ", oneShot=" + oneShot + "]";
     }
 
     static <L extends RListener> Cons<L> insert (Cons<L> head, Cons<L> cons) {
         if (head == null) {
             return cons;
-        } else if (head.listener.priority() > cons.listener.priority()) {
+        } else if (head.getListener().priority() > cons.getListener().priority()) {
             cons.next = head;
             return cons;
         } else {
@@ -64,7 +62,7 @@ class Cons<L extends RListener> implements Connection
 
     static <L extends RListener> Cons<L> removeAll (Cons<L> head, Object listener) {
         if (head == null) return null;
-        if (head.listener == listener) return removeAll(head.next, listener);
+        if (head.getListener() == listener) return removeAll(head.next, listener);
         head.next = removeAll(head.next, listener);
         return head;
     }

--- a/src/main/java/react/RList.java
+++ b/src/main/java/react/RList.java
@@ -74,6 +74,7 @@ public class RList<E> extends Reactor<RList.Listener<E>>
      * Creates a reactive list with the supplied underlying list implementation.
      */
     public RList (List<E> impl) {
+        super(new Listener<E>() {});
         _impl = impl;
     }
 
@@ -313,7 +314,7 @@ public class RList<E> extends Reactor<RList.Listener<E>>
         try {
             for (Cons<Listener<E>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onAdd(index, elem);
+                    cons.getListener().onAdd(index, elem);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);
@@ -332,7 +333,7 @@ public class RList<E> extends Reactor<RList.Listener<E>>
         try {
             for (Cons<Listener<E>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onSet(index, newElem, oldElem);
+                    cons.getListener().onSet(index, newElem, oldElem);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);
@@ -351,7 +352,7 @@ public class RList<E> extends Reactor<RList.Listener<E>>
         try {
             for (Cons<Listener<E>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onRemove(index, elem);
+                    cons.getListener().onRemove(index, elem);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);

--- a/src/main/java/react/RMap.java
+++ b/src/main/java/react/RMap.java
@@ -72,6 +72,7 @@ public class RMap<K,V> extends Reactor<RMap.Listener<K,V>>
      * Creates a reactive map with the supplied underlying map implementation.
      */
     public RMap (Map<K,V> impl) {
+        super(new Listener<K, V>() {});
         _impl = impl;
     }
 
@@ -434,7 +435,7 @@ public class RMap<K,V> extends Reactor<RMap.Listener<K,V>>
         try {
             for (Cons<Listener<K,V>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onPut(key, value, oldValue);
+                    cons.getListener().onPut(key, value, oldValue);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);
@@ -457,7 +458,7 @@ public class RMap<K,V> extends Reactor<RMap.Listener<K,V>>
         try {
             for (Cons<Listener<K,V>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onRemove(key, oldValue);
+                    cons.getListener().onRemove(key, oldValue);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);

--- a/src/main/java/react/RSet.java
+++ b/src/main/java/react/RSet.java
@@ -54,6 +54,7 @@ public class RSet<E> extends Reactor<RSet.Listener<E>>
      * Creates a reactive set with the supplied underlying set implementation.
      */
     public RSet (Set<E> impl) {
+        super(new Listener<E>() {});
         _impl = impl;
     }
 
@@ -273,7 +274,7 @@ public class RSet<E> extends Reactor<RSet.Listener<E>>
         try {
             for (Cons<Listener<E>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onAdd(elem);
+                    cons.getListener().onAdd(elem);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);
@@ -296,7 +297,7 @@ public class RSet<E> extends Reactor<RSet.Listener<E>>
         try {
             for (Cons<Listener<E>> cons = lners; cons != null; cons = cons.next) {
                 try {
-                    cons.listener.onRemove(elem);
+                    cons.getListener().onRemove(elem);
                 } catch (Throwable t) {
                     if (error == null) error = new MultiFailureException();
                     error.addFailure(t);

--- a/src/main/java/react/StrongCons.java
+++ b/src/main/java/react/StrongCons.java
@@ -1,0 +1,17 @@
+package react;
+
+public class StrongCons<L extends Reactor.RListener> extends Cons<L> {
+
+    /** Receives signals from the reactor. */
+    private final L listener;
+
+    public StrongCons(Reactor<L> owner, L listener) {
+        super(owner);
+        this.listener = listener;
+    }
+
+    @Override
+    public L getListener() {
+        return listener;
+    }
+}

--- a/src/main/java/react/ValueView.java
+++ b/src/main/java/react/ValueView.java
@@ -39,10 +39,18 @@ public interface ValueView<T>
 
     /**
      * Connects the supplied listener to this value, such that it will be notified when this value
-     * changes.
+     * changes. The listener is held by a strong reference, so it's held in memory by virtue of being connected.
      * @return a connection instance which can be used to cancel the connection.
      */
     Connection connect (Listener<? super T> listener);
+
+    /**
+     * Connects the supplied listener to this value, such that it will be notified when this value
+     * changes. The listener is only held by a weak reference, so it only remains in memory and connected as long as
+     * it's referenced elsewhere.
+     * @return a connection instance which can be used to cancel the connection.
+     */
+    Connection connectWeak (Listener<? super T> listener);
 
     /**
      * Connects the supplied listener to this value, such that it will be notified when this value

--- a/src/main/java/react/WeakCons.java
+++ b/src/main/java/react/WeakCons.java
@@ -1,0 +1,23 @@
+package react;
+
+import java.lang.ref.WeakReference;
+
+class WeakCons<L extends Reactor.RListener> extends Cons<L> {
+
+    private final WeakReference<L> _weakListener;
+
+    public WeakCons(Reactor<L> owner, L listener) {
+        super(owner);
+        _weakListener = new WeakReference<L>(listener);
+    }
+
+    @Override
+    public L getListener() {
+        L listener = _weakListener.get();
+        if (listener == null) {
+            listener = owner.placeholderListener;
+            disconnect();
+        }
+        return listener;
+    }
+}

--- a/src/test/java/react/ValueTest.java
+++ b/src/test/java/react/ValueTest.java
@@ -6,6 +6,9 @@
 package react;
 
 import org.junit.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.Assert.*;
 
 /**
@@ -141,5 +144,31 @@ public class ValueTest
         value.connect(listener).disconnect();
         value.update((expectedValue[0] = 14));
         assertEquals(1, fired[0]);
+    }
+
+    @Test public void testWeakListener () {
+        final Value<Integer> value = Value.create(42);
+        final AtomicInteger fired = new AtomicInteger(0);
+
+        ValueView.Listener<Integer> listener = new ValueView.Listener<Integer>() {
+            @Override
+            public void onChange(Integer value, Integer oldValue) {
+                fired.incrementAndGet();
+            }
+        };
+        System.gc();
+        System.gc();
+        System.gc();
+        value.addConnectionWeak(listener);
+        value.update(41);
+        assertEquals(1, fired.get());
+        assertTrue(value.hasConnections());
+        listener = null;
+        System.gc();
+        System.gc();
+        System.gc();
+        value.update(40);
+        assertEquals(1, fired.get());
+        assertFalse(value.hasConnections());
     }
 }


### PR DESCRIPTION
If I remember correctly, we didn't add a weak referenced version of connections back in the day because GWT doesn't support WeakReference. I'm now using react on Android, which does support them. I'd very much like to be able to add listeners without needing to worry about disconnecting them when I'm done.

This just implements weak connections for Values. Before completing the implementation for the other Reactor subclasses I wanted to check if a change like this would be accepted upstream and if it needed to be done differently to keep from breaking GWT. Yea? Nay? Maybe?

Also, this doesn't handle priority properly if a weak listener has a non-zero priority. If another listener with a non-zero priority is connected while that listener is still in the Cons list but garbage collected, it'll look like the weak listener has a priority of zero.

However, I think priority is broken in general. It's a method on the listener, so it can change after the listener has been added. The Reactor can't detect that that priority has changed though, so it doesn't resort its list. Seems like the priority should be on the Connection and not the Listener, which would fix the weak listener case as well.
