### PR TITLE
Move listener ref weakening to Connection

### DIFF
--- a/src/main/java/react/AbstractSignal.java
+++ b/src/main/java/react/AbstractSignal.java
@@ -30,10 +30,6 @@ public class AbstractSignal<T> extends Reactor<Slot<T>>
         return addConnection(slot);
     }
 
-    @Override public Connection connectWeak (Slot<? super T> slot) {
-        return addConnectionWeak(slot);
-    }
-
     @Override public void disconnect (Slot<? super T> slot) {
         removeConnection(slot);
     }

--- a/src/main/java/react/AbstractValue.java
+++ b/src/main/java/react/AbstractValue.java
@@ -34,10 +34,6 @@ public abstract class AbstractValue<T> extends Reactor<ValueView.Listener<T>>
         return addConnection(listener);
     }
 
-    @Override public Connection connectWeak (Listener<? super T> listener) {
-        return addConnectionWeak(listener);
-    }
-
     @Override public Connection connectNotify (Listener<? super T> listener) {
         // connect before calling emit; if the listener changes the value in the body of onEmit, it
         // will expect to be notified of that change; however if onEmit throws a runtime exception,

--- a/src/main/java/react/Connection.java
+++ b/src/main/java/react/Connection.java
@@ -37,4 +37,15 @@ public interface Connection
      * @return this connection instance for convenient chaining.
      */
     Connection atPriority (int priority);
+
+    /**
+     * Changes the listener to be held by a weak reference, so it only remains in memory and
+     * connected only as long as it's referenced elsewhere.
+     *
+     * <p><em>NOTE:</em> weak references are not supported in JavaScript. When using this library
+     * in GWT, the reference remains strong.</p>
+     *
+     * @return this connection instance for convenient chaining.
+     */
+    Connection holdWeakly();
 }

--- a/src/main/java/react/Reactor.java
+++ b/src/main/java/react/Reactor.java
@@ -5,14 +5,13 @@
 
 package react;
 
-import java.lang.ref.WeakReference;
-
 /**
  * A base class for all reactive classes. This is an implementation detail, but is public so that
  * third parties may use it to create their own reactive classes, if desired.
  */
 public abstract class Reactor<L extends Reactor.RListener>
 {
+
     /** The base class for all reactor listeners. */
     public abstract static class RListener {}
 
@@ -33,26 +32,7 @@ public abstract class Reactor<L extends Reactor.RListener>
         // plain type variable (L) and Java doesn't have the higher kinded type machinery needed to
         // let the compiler know that what we're doing is safe; so we just cast
         @SuppressWarnings("unchecked") final L casted = (L)listener;
-        return addCons(new Cons<L>(this) {
-            @Override public L listener() { return casted; }
-        });
-    }
-
-    protected synchronized Cons<L> addConnectionWeak (Object listener) {
-        if (listener == null) throw new NullPointerException("Null listener");
-        // see addConnection for details on why this cast is safe
-        @SuppressWarnings("unchecked") final L casted = (L)listener;
-        final WeakReference<L> weak = new WeakReference<L>(casted);
-        return addCons(new Cons<L>(this) {
-            @Override public L listener () {
-                L listener = weak.get();
-                if (listener == null) {
-                    listener = _owner.placeholderListener();
-                    disconnect();
-                }
-                return listener;
-            }
-        });
+        return addCons(new Cons<L>(this, casted));
     }
 
     protected synchronized Cons<L> addCons (final Cons<L> cons) {
@@ -166,7 +146,5 @@ public abstract class Reactor<L extends Reactor.RListener>
         public Runs next;
     }
 
-    protected static final Cons<RListener> DISPATCHING = new Cons<RListener>(null) {
-        @Override public RListener listener () { return null; }
-    };
+    protected static final Cons<RListener> DISPATCHING = new Cons<RListener>(null, null);
 }

--- a/src/main/java/react/SignalView.java
+++ b/src/main/java/react/SignalView.java
@@ -28,18 +28,6 @@ public interface SignalView<T>
     Connection connect (Slot<? super T> slot);
 
     /**
-     * Connects this signal to the supplied slot, such that when an event is emitted from this
-     * signal, the slot will be notified. The slot is only held by a weak reference, so it only
-     * remains in memory and connected as long as it's referenced elsewhere.
-     *
-     * <p><em>NOTE:</em> weak references are not supported in JavaScript. When using this library
-     * in GWT, this will result in a strong connection.</p>
-     *
-     * @return a connection instance which can be used to cancel the connection.
-     */
-    Connection connectWeak (Slot<? super T> slot);
-
-    /**
      * Disconnects the supplied slot from this signal if connect was called with it. If the slot has
      * been connected multiple times, all connections are cancelled.
      */

--- a/src/main/java/react/ValueView.java
+++ b/src/main/java/react/ValueView.java
@@ -47,18 +47,6 @@ public interface ValueView<T>
 
     /**
      * Connects the supplied listener to this value, such that it will be notified when this value
-     * changes. The listener is only held by a weak reference, so it only remains in memory and
-     * connected as long as it's referenced elsewhere.
-     *
-     * <p><em>NOTE:</em> weak references are not supported in JavaScript. When using this library
-     * in GWT, this will result in a strong connection.</p>
-     *
-     * @return a connection instance which can be used to cancel the connection.
-     */
-    Connection connectWeak (Listener<? super T> listener);
-
-    /**
-     * Connects the supplied listener to this value, such that it will be notified when this value
      * changes. Also immediately notifies the listener of the current value. Note that the previous
      * value supplied with this notification will be null. If the notification triggers an
      * unchecked exception, the slot will automatically be disconnected and the caller need not

--- a/src/main/java/react/Values.java
+++ b/src/main/java/react/Values.java
@@ -139,6 +139,10 @@ public class Values
                         for (Connection conn : conns) conn.atPriority(priority);
                         return this;
                     }
+                    public Connection holdWeakly() {
+                        for (Connection conn : conns) conn.holdWeakly();
+                        return this;
+                    }
                 };
             }
 

--- a/src/test/java/react/ValueTest.java
+++ b/src/test/java/react/ValueTest.java
@@ -159,7 +159,7 @@ public class ValueTest
         System.gc();
         System.gc();
         System.gc();
-        value.addConnectionWeak(listener);
+        value.addConnection(listener).holdWeakly().holdWeakly();
         value.update(41);
         assertEquals(1, fired.get());
         assertTrue(value.hasConnections());


### PR DESCRIPTION
I actually mainly use connectNotify, so the merged request from yesterday doesn't actually let me kick the tires. I was planning on adding the rest of the *Weak methods if the general idea was workable. I did say it was incomplete in the request :stuck_out_tongue_winking_eye:.

In any case, this is probably a better implementation. It adds a single `holdWeakly` method to Connection and doesn't clutter up all of the Reactor subclasses with *Weak methods.
