### PR TITLE
Remove the dependency on Objects to be compatible with Android prior API 19

### DIFF
--- a/src/main/java/react/Closeable.java
+++ b/src/main/java/react/Closeable.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
  * {@link #close}. React resources generally do not encounter failure during closure, thus the
  * checked exception is a needless burden to pass on to callers.
  */
-public interface Closeable extends AutoCloseable {
+public interface Closeable {
 
     /** Maintains a set of closeables to allow mass operations on them. */
     class Set implements Closeable {

--- a/src/main/java/react/Closeable.java
+++ b/src/main/java/react/Closeable.java
@@ -25,7 +25,7 @@ public interface Closeable {
                     c.close();
                 } catch (Exception e) {
                     if (error == null) error = new MultiFailureException();
-                    error.addSuppressed(e);
+                    error.addFailure(e);
                 }
                 _set.clear();
                 if (error != null) throw error;

--- a/src/main/java/react/ObjectsUtil.java
+++ b/src/main/java/react/ObjectsUtil.java
@@ -1,0 +1,15 @@
+package react;
+
+/** This is used to keep compatible with Android prior to API 19. */
+final class ObjectsUtil {
+	
+	/** Utility method for getting object's hash code */
+	static int hashCode(Object o) {
+		return o != null ? o.hashCode() : 0;
+	}
+
+	/** Utility method for comparing two objects' equality */
+	static boolean equals(Object a, Object b) {
+		return (a == b) || (a != null && a.equals(b));
+	}
+}

--- a/src/main/java/react/RFuture.java
+++ b/src/main/java/react/RFuture.java
@@ -291,21 +291,6 @@ public abstract class RFuture<T> extends Reactor {
         return mapped;
     }
 
-    /** This is used to keep compatible with Android prior to API 19. */
-    final private static class ObjectsUtil {
-    	
-    	/** Utility method for getting object's hash code */
-    	private static int hashCode(Object o) {
-    		return o != null ? o.hashCode() : 0;
-    	}
-
-    	/** Utility method for comparing two objects' equality */
-    	private static boolean equals(Object a, Object b) {
-    		return (a == b) || (a != null && a.equals(b));
-    	}
-    }
-
-
     /** Returns the result of this future, or null if it is not yet complete.
       *
       * <p><em>NOTE:</em> don't use this method! You should wire up reactions to the completion of

--- a/src/main/java/react/RFuture.java
+++ b/src/main/java/react/RFuture.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Represents an asynchronous result. Unlike standard Java futures, you cannot block on this
@@ -36,12 +35,12 @@ public abstract class RFuture<T> extends Reactor {
         }
 
         @Override public int hashCode () {
-            return Objects.hashCode(a) ^ Objects.hashCode(b);
+            return ObjectsUtil.hashCode(a) ^ ObjectsUtil.hashCode(b);
         }
         @Override public boolean equals (Object other) {
             if (!(other instanceof T2<?,?>)) return false;
             T2<?,?> ot = (T2<?,?>)other;
-            return Objects.equals(a, ot.a) && Objects.equals(a, ot.b);
+            return ObjectsUtil.equals(a, ot.a) && ObjectsUtil.equals(a, ot.b);
         }
     }
 
@@ -57,12 +56,12 @@ public abstract class RFuture<T> extends Reactor {
         }
 
         @Override public int hashCode () {
-            return Objects.hashCode(a) ^ Objects.hashCode(b);
+            return ObjectsUtil.hashCode(a) ^ ObjectsUtil.hashCode(b);
         }
         @Override public boolean equals (Object other) {
             if (!(other instanceof T3<?,?,?>)) return false;
             T3<?,?,?> ot = (T3<?,?,?>)other;
-            return Objects.equals(a, ot.a) && Objects.equals(a, ot.b) && Objects.equals(c, ot.c);
+            return ObjectsUtil.equals(a, ot.a) && ObjectsUtil.equals(a, ot.b) && ObjectsUtil.equals(c, ot.c);
         }
     }
 
@@ -291,6 +290,21 @@ public abstract class RFuture<T> extends Reactor {
         });
         return mapped;
     }
+
+    /** This is used to keep compatible with Android prior to API 19. */
+    final private static class ObjectsUtil {
+    	
+    	/** Utility method for getting object's hash code */
+    	private static int hashCode(Object o) {
+    		return o != null ? o.hashCode() : 0;
+    	}
+
+    	/** Utility method for comparing two objects' equality */
+    	private static boolean equals(Object a, Object b) {
+    		return (a == b) || (a != null && a.equals(b));
+    	}
+    }
+
 
     /** Returns the result of this future, or null if it is not yet complete.
       *

--- a/src/main/java/react/Values.java
+++ b/src/main/java/react/Values.java
@@ -8,7 +8,6 @@ package react;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Objects;
 
 /**
  * Provides utility methods for {@link Value}s.
@@ -28,12 +27,12 @@ public class Values
             return "T2(" + a + ", " + b + ")";
         }
         @Override public int hashCode () {
-            return Objects.hashCode(a) ^ Objects.hashCode(b);
+            return ObjectsUtil.hashCode(a) ^ ObjectsUtil.hashCode(b);
         }
         @Override public boolean equals (Object other) {
             if (!(other instanceof T2<?,?>)) return false;
             T2<?,?> ot = (T2<?,?>)other;
-            return Objects.equals(a, ot.a) && Objects.equals(b, ot.b);
+            return ObjectsUtil.equals(a, ot.a) && ObjectsUtil.equals(b, ot.b);
         }
     }
 
@@ -52,12 +51,12 @@ public class Values
             return "T3(" + a + ", " + b + ", " + c + ")";
         }
         @Override public int hashCode () {
-            return Objects.hashCode(a) ^ Objects.hashCode(b);
+            return ObjectsUtil.hashCode(a) ^ ObjectsUtil.hashCode(b);
         }
         @Override public boolean equals (Object other) {
             if (!(other instanceof T3<?,?,?>)) return false;
             T3<?,?,?> ot = (T3<?,?,?>)other;
-            return Objects.equals(a, ot.a) && Objects.equals(b, ot.b) && Objects.equals(c, ot.c);
+            return ObjectsUtil.equals(a, ot.a) && ObjectsUtil.equals(b, ot.b) && ObjectsUtil.equals(c, ot.c);
         }
     }
 


### PR DESCRIPTION
Actually, @SafeVarargs was introduced from API 19, but can be ignored without harm.